### PR TITLE
Add simple check to avoid setting startpos when editing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,6 +505,11 @@ class $modify(CEditorUI, EditorUI) {
     }
 
     void onCreateStartpos(CCObject*) {
+		// Dont create SP when editing (not tested)
+		if (!m_editorLayer->m_isPlaying) {
+			return false;
+		}
+
         auto pl = m_editorLayer->m_player1;
         StartPosObject* sp = static_cast<StartPosObject*>(m_editorLayer->createObjectsFromString(fmt::format("1,31,2,{},3,{}", pl->getPositionX(), pl->getPositionY() - 90).c_str(), false, false)->firstObject());
         auto settings = sp->m_startSettings;


### PR DESCRIPTION
With a keybind set, you sometimes press it while actually editing, which can result in placing the start pos triggers unwillingly. A user already reported this issue yet not solved yet.

It's not tested, it's just a band-aid fix that should work.